### PR TITLE
Removed bcrypt and mongo_cookie authenticator (LP#13764927)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-.env
+.env*

--- a/lib/cube/authentication.js
+++ b/lib/cube/authentication.js
@@ -17,8 +17,6 @@
 //
 
 var mongodb  = require("mongodb"),
-    cookies  = require("cookies"),
-    bcrypt   = require("bcrypt"),
     metalog  = require('./metalog'),
     url      = require('url')
     ;
@@ -191,63 +189,6 @@ authentication.read_only = function(){
     metalog.event('cube_auth', { authenticator: 'read_only', path: request.url }, 'minor');
     request.authorized = { admin: false };
     return auth_ok(request.authorized);
-  };
-  return { check: check };
-};
-
-authentication.mongo_cookie = function(db, options){
-  var users;
-
-  db.collection(options["collection"]||"users", function(error, clxn){
-    if (error) throw(error);
-    // TODO: check if not collection?
-    users = clxn;
-  });
-
-  function check(request, auth_ok, auth_no) {
-    var cookie       = (new cookies(request)).get('_cube_session'),
-        token        = decodeURIComponent(cookie).split('--'), // token[0] = token uid, token[1] = token secret
-        token_uid    = new Buffer(token[0] + '', 'base64').toString('utf8'),
-        token_secret = new Buffer(token[1] + '', 'base64').toString('utf8');
-
-    metalog.event('cube_auth', { is: 'hi', tu: token_uid }, 'minor');
-
-    if (! (cookie && token && token_uid && token_secret)){
-      metalog.event('cube_auth', { is: 'no', r: 'no_token_in_request' });
-      auth_no('no_token_in_request');
-      return;
-    };
-
-    validate_token({"tokens.uid": token_uid}, auth_ok, auth_no);
-
-    function validate_token(query, auth_ok, auth_no){
-      // Asynchronously load the requested user.
-      users.findOne(query, function(error, user) {
-        if((!error) && user) {
-          metalog.event('cube_auth', { is: 'ok', tu: token_uid, u: user._id }, 'minor');
-          var auth_info = user.tokens.filter(function(t){ return t.uid === token_uid; });
-
-          if(auth_info.length === 1){
-            bcrypt.compare(token_secret, auth_info[0].hashed_secret, function(err, res) {
-              if (!err && res === true ){
-                delete auth_info[0].hashed_secret;
-                request.authorized = auth_info[0];
-                auth_ok(request.authorized);
-              } else {
-                metalog.event('cube_auth', { is: 'no', r: 'bad_token', tu: token_uid, u: user });
-                auth_no('bad_token');
-              }
-            });
-          } else {
-            metalog.event('cube_auth', { is: 'no', r: 'missing_token', tu: token_uid, u: user });
-            auth_no('missing_token');
-          }
-        } else {
-          metalog.event('cube_auth', { is: 'no', r: 'missing_user', tu: token_uid });
-          auth_no('missing_user');
-        };
-      });
-    };
   };
   return { check: check };
 };

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "vows": "0.5.11",
     "websocket": "1.0.3",
     "websocket-server": "1.4.04",
-    "node-gyp": "~0.6.8",
-    "cookies": "0.3.1",
-    "bcrypt": "~0.7.7"
+    "node-gyp": "~0.6.8"
   }
 }


### PR DESCRIPTION
The evaluator and collector no longer error out when started under node@0.11.8; However, there are now constant notices about using `console.log` instead of `util.log`/`util.debug` as apparently that is what cube uses.
